### PR TITLE
Add svg for community badge

### DIFF
--- a/community-badge.svg
+++ b/community-badge.svg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="164"
+   height="51"
+   viewBox="0 0 164 51"
+   id="svg2"
+   version="1.1"
+   sodipodi:docname="community-badge.svg"
+   xml:space="preserve"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   inkscape:export-filename="community-badge.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:current-layer="svg2"><inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="0.5"
+       spacingy="0.5"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.0784314"
+       empspacing="2"
+       enabled="true"
+       visible="false" /><inkscape:page
+       x="0"
+       y="0"
+       width="164"
+       height="51"
+       id="page11"
+       margin="0"
+       bleed="0" /></sodipodi:namedview><defs
+     id="defs4"><linearGradient
+       id="linearGradient4755"><stop
+         id="stop4757"
+         offset="0"
+         style="stop-color:#a56de2;stop-opacity:1" /><stop
+         id="stop4759"
+         offset="1"
+         style="stop-color:#7239b3;stop-opacity:1" /></linearGradient><style
+       id="current-color-scheme"
+       type="text/css">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      .ColorScheme-Background {
+        color:#eff0f1;
+      }
+      .ColorScheme-Highlight {
+        color:#3daee9;
+      }
+      .ColorScheme-ViewText {
+        color:#31363b;
+      }
+      .ColorScheme-ViewBackground {
+        color:#fcfcfc;
+      }
+      .ColorScheme-ViewHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ViewFocus{
+        color:#3daee9;
+      }
+      .ColorScheme-ButtonText {
+        color:#31363b;
+      }
+      .ColorScheme-ButtonBackground {
+        color:#eff0f1;
+      }
+      .ColorScheme-ButtonHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ButtonFocus{
+        color:#3daee9;
+      }
+      </style><linearGradient
+       id="linearGradient4136-3"
+       y2="27.419167"
+       xlink:href="#linearGradient5340"
+       gradientUnits="userSpaceOnUse"
+       x2="112.21632"
+       gradientTransform="matrix(2.4133843,0,0,2.407125,80.17889,952.36086)"
+       y1="9.1400986"
+       x1="112.21632" /><linearGradient
+       id="linearGradient5340"><stop
+         offset="0"
+         stop-color="#fff"
+         id="stop5342" /><stop
+         offset="0.04545455"
+         stop-opacity=".23529"
+         stop-color="#fff"
+         id="stop5344" /><stop
+         offset="0.95454544"
+         stop-opacity=".15686"
+         stop-color="#fff"
+         id="stop5346" /><stop
+         offset="1"
+         stop-opacity=".39216"
+         stop-color="#fff"
+         id="stop5348" /></linearGradient><linearGradient
+       gradientTransform="matrix(0.99375,0,0,0.97916667,195.0196,18.799244)"
+       gradientUnits="userSpaceOnUse"
+       y2="1024.9153"
+       x2="99.016075"
+       y1="955.46851"
+       x1="99.016075"
+       id="linearGradient4761-6"
+       xlink:href="#linearGradient4755" /><style
+       id="current-color-scheme-9"
+       type="text/css">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      .ColorScheme-Background {
+        color:#eff0f1;
+      }
+      .ColorScheme-Highlight {
+        color:#3daee9;
+      }
+      .ColorScheme-ViewText {
+        color:#31363b;
+      }
+      .ColorScheme-ViewBackground {
+        color:#fcfcfc;
+      }
+      .ColorScheme-ViewHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ViewFocus{
+        color:#3daee9;
+      }
+      .ColorScheme-ButtonText {
+        color:#31363b;
+      }
+      .ColorScheme-ButtonBackground {
+        color:#eff0f1;
+      }
+      .ColorScheme-ButtonHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ButtonFocus{
+        color:#3daee9;
+      }
+      </style></defs><metadata
+     id="metadata7"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><g
+     id="layer1"
+     transform="translate(-195,-971.36218)"><rect
+       style="color:#fbc02d;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:-4.84px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#206b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect3347-7-6-1-5-8-2-3-3-9"
+       width="164"
+       height="51"
+       x="195"
+       y="971.36218"
+       rx="5.5"
+       ry="5.5" /><rect
+       style="color:#fbc02d;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:-4.84px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#206b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect3347-7-6-1-5-8-2-3-3"
+       width="162"
+       height="49"
+       x="196"
+       y="972.36218"
+       rx="4.5"
+       ry="4.5" /><rect
+       style="color:#fbc02d;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:-4.84px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect3347-7-6-1-5-8-2-3"
+       width="159"
+       height="47"
+       x="197.5"
+       y="972.86218"
+       rx="3"
+       ry="3" /><rect
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:-4.84px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.4;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:20;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect3347-7-6-1-5-8-2-7"
+       width="159"
+       height="47"
+       x="197.5"
+       y="972.86218"
+       rx="3"
+       ry="3.0000002" /><rect
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:-4.84px;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4136-3);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect3347-7-6-1-5-8-2-7-1"
+       width="157"
+       height="45"
+       x="198.5"
+       y="973.86218"
+       rx="2"
+       ry="2" /></g><g
+     id="g14"
+     style="opacity:0.4;fill:#206b00;stroke:#206b00"><path
+       style="fill:#206b00;stroke:#206b00;stroke-width:0.945946;stroke-dasharray:none;stroke-opacity:1"
+       d="M 25,8.9729733 C 15.5962,8.9729733 7.972973,16.5962 7.972973,26 7.972973,35.4038 15.5962,43.027027 25,43.027027 34.4038,43.027027 42.027027,35.4038 42.027027,26 42.027027,16.5962 34.4038,8.9729733 25,8.9729733 Z M 12.661535,34.285351 c -0.202849,0.02458 -0.404732,0.04064 -0.604232,0.05012 -0.06805,0.0033 -0.135762,0.0052 -0.203189,0.0063 C 10.320886,31.930514 9.4322459,29.069122 9.4322459,26 9.4322459,17.402146 16.402146,10.432189 25,10.432189 c 8.355276,0 15.17233,6.582308 15.5505,14.844162 -0.144105,0.401498 -0.30257,0.798 -0.476076,1.186614 -0.362278,0.808443 -0.786762,1.58777 -1.297856,2.292859 -0.254554,0.353027 -0.53289,0.684884 -0.8337,0.988419 -0.15103,0.150973 -0.307849,0.294625 -0.4704,0.429479 -0.162949,0.134229 -0.332652,0.257846 -0.507406,0.371416 -0.174527,0.114081 -0.355808,0.215108 -0.54214,0.30257 -0.18639,0.08712 -0.376808,0.164651 -0.572619,0.222997 -0.195471,0.05897 -0.39463,0.104092 -0.596287,0.135252 -0.100913,0.01192 -0.204665,0.02696 -0.298484,0.03161 l -0.07202,0.0056 c -0.02191,0.0026 -0.05522,0.0019 -0.08224,0.003 l -0.158976,0.0038 c -0.08752,-5.7e-5 -0.174754,-0.0024 -0.261762,-0.0061 0.454281,-0.505532 0.869343,-1.049489 1.229748,-1.637659 0.2436,-0.4011 0.460354,-0.824165 0.628014,-1.280773 0.08343,-0.228446 0.154094,-0.465746 0.202394,-0.716157 0.04773,-0.250297 0.0752,-0.514216 0.05295,-0.797149 -0.01135,-0.141154 -0.03604,-0.287473 -0.08332,-0.435892 -0.04614,-0.147794 -0.116068,-0.298029 -0.214598,-0.436062 -0.09717,-0.138297 -0.224927,-0.260948 -0.365059,-0.354881 -0.1407,-0.09314 -0.292468,-0.160054 -0.440773,-0.201146 -0.148589,-0.042 -0.294397,-0.06306 -0.43453,-0.07106 -0.03542,-0.0026 -0.06975,-0.003 -0.104319,-0.0036 l -0.02588,-3.97e-4 h -0.03229 l -0.04149,8.51e-4 -0.04143,8.52e-4 -0.0508,0.0024 c -0.03451,0.0021 -0.07208,0.0032 -0.103922,0.0067 -0.262613,0.02123 -0.534478,0.07861 -0.794651,0.189681 -0.259776,0.110165 -0.504908,0.274929 -0.702649,0.479027 -0.199613,0.203075 -0.351665,0.439638 -0.464384,0.681989 -0.01305,0.02832 -0.02548,0.05676 -0.03757,0.08531 -0.03491,-0.03922 -0.07078,-0.07798 -0.108802,-0.11567 -0.20319,-0.201259 -0.45973,-0.376808 -0.752595,-0.477665 -0.145468,-0.05097 -0.297859,-0.08292 -0.449059,-0.09654 -0.07594,-0.0065 -0.150179,-0.0098 -0.226176,-0.0073 l -0.03729,0.0021 -0.04081,0.003 c -0.0231,0.0027 -0.0462,0.0053 -0.06936,0.0089 -0.04631,0.0075 -0.09268,0.01697 -0.138487,0.02991 -0.184232,0.05 -0.355183,0.148476 -0.488562,0.268005 -0.134854,0.11953 -0.234689,0.256881 -0.311538,0.39463 -0.152165,0.277541 -0.219535,0.558657 -0.252283,0.830806 -0.06016,0.545318 0.02157,1.067764 0.18321,1.557916 0.163517,0.48964 0.416765,0.946362 0.742208,1.344794 0.325046,0.398773 0.723082,0.73693 1.162663,0.996479 0.158181,0.09382 0.321583,0.177081 0.488335,0.251035 -1.029965,0.821213 -2.185022,1.488786 -3.408016,1.974397 -0.789317,0.310346 -1.605592,0.550257 -2.437192,0.709176 -0.831714,0.156989 -1.67773,0.239343 -2.522611,0.245586 -0.428287,0.0024 -0.837843,-0.01181 -1.248933,-0.05636 -0.204948,-0.02117 -0.408535,-0.04926 -0.610192,-0.08485 -0.202054,-0.03388 -0.401554,-0.07725 -0.599294,-0.125489 -0.730289,-0.179578 -1.426581,-0.459389 -2.06203,-0.832054 0.797149,-0.431408 1.571084,-0.902432 2.3247,-1.403992 1.50763,-1.010837 2.935289,-2.150627 4.211635,-3.463694 0.637606,-0.656279 1.237014,-1.355862 1.776714,-2.107265 0.270275,-0.375219 0.524262,-0.764343 0.760086,-1.166351 0.234576,-0.402746 0.449003,-0.819682 0.639479,-1.249841 0.379816,-0.860092 0.656448,-1.780857 0.773367,-2.734597 0.02912,-0.238208 0.04921,-0.478006 0.05715,-0.718711 0.0013,-0.06022 0.0036,-0.120381 0.0041,-0.1806 l -2.27e-4,-0.195243 -0.0058,-0.165844 -0.0032,-0.08292 -0.0019,-0.04223 -0.0038,-0.04802 -0.01572,-0.191838 -0.0085,-0.09547 -0.01198,-0.09132 -0.02475,-0.18253 c -0.0084,-0.06073 -0.02174,-0.121118 -0.03247,-0.181678 -0.04245,-0.242294 -0.106759,-0.481297 -0.177876,-0.717632 -0.148759,-0.471422 -0.362392,-0.923433 -0.626027,-1.342184 l -0.103486,-0.154378 -0.05205,-0.07679 -0.05556,-0.07447 -0.111357,-0.148306 -0.118394,-0.1428 -0.05943,-0.07106 -0.06266,-0.06828 -0.125489,-0.13616 -0.131619,-0.130086 -0.06612,-0.06465 -0.0689,-0.06158 C 27.868705,15.918016 27.670623,15.771016 27.47135,15.62816 27.368507,15.56113 27.268559,15.4899 27.161856,15.429568 c -0.0529,-0.03093 -0.104943,-0.06317 -0.158522,-0.09274 l -0.162154,-0.08576 c -0.434634,-0.223965 -0.89618,-0.390263 -1.368339,-0.502584 -0.118849,-0.02407 -0.236619,-0.05437 -0.356603,-0.07174 l -0.179352,-0.02951 -0.180316,-0.02151 c -0.119984,-0.01731 -0.240875,-0.02134 -0.361427,-0.0319 -0.06033,-0.0033 -0.120721,-0.0041 -0.181111,-0.0061 l -0.09058,-0.0026 -0.02265,-6.24e-4 -0.0315,-5.7e-5 -0.04149,3.4e-4 -0.1659,0.0012 -0.186333,0.0081 c -0.06351,0.0023 -0.123503,0.0072 -0.182927,0.01249 -0.05977,0.0056 -0.11987,0.009 -0.179351,0.01657 -0.238833,0.02548 -0.474884,0.06658 -0.70946,0.1134 -0.937054,0.198024 -1.819508,0.575059 -2.628632,1.05244 -0.812133,0.476416 -1.548268,1.062714 -2.220665,1.709684 -0.670411,0.649751 -1.271976,1.367781 -1.800324,2.138765 -0.527668,0.771381 -0.982233,1.597022 -1.340425,2.471757 -0.359894,0.873486 -0.623983,1.797316 -0.751402,2.75991 -0.03167,0.240479 -0.05329,0.483568 -0.06521,0.728473 -0.0071,0.122254 -0.0093,0.24536 -0.01118,0.368522 l -5.11e-4,0.05358 1.7e-4,0.04149 3.98e-4,0.08298 7.38e-4,0.08292 3.97e-4,0.04155 0.0012,0.04569 c 0.006,0.247062 0.01663,0.478913 0.03468,0.716384 0.01805,0.236448 0.04132,0.472954 0.07299,0.709005 0.06243,0.471989 0.154833,0.942049 0.274306,1.406886 0.122708,0.464271 0.275043,0.922582 0.46041,1.369711 0.186049,0.446733 0.405981,0.881319 0.658379,1.298084 0.253873,0.415857 0.542367,0.811962 0.86083,1.183151 0.08372,0.0966 0.169418,0.191498 0.257051,0.284692 -0.03093,0.01215 -0.06175,0.02469 -0.09274,0.03667 -0.797602,0.307962 -1.611097,0.566943 -2.428792,0.752765 -0.408535,0.0924 -0.818148,0.166184 -1.224016,0.213632 z m 20.422784,-3.252616 c -0.101651,0 -0.480105,-0.136046 -0.910946,-0.42193 -0.307451,-0.193994 -0.582438,-0.434075 -0.811565,-0.712864 -0.416367,-0.486633 -0.742889,-1.137179 -0.742889,-1.968211 0,-0.548611 0.146489,-0.912422 0.463532,-0.912422 0.06958,0 0.14246,0.01232 0.217152,0.03354 0.02628,0.0065 0.05222,0.01385 0.0777,0.02282 0.03905,0.01345 0.0773,0.03014 0.114932,0.04938 0.616379,0.284181 1.279241,1.043076 1.279241,1.043076 0,0 0.537486,-1.882338 1.990686,-1.882338 0.200862,0 0.348884,0.03428 0.457914,0.09155 0.0076,0.0039 0.01538,0.0078 0.02248,0.01181 0.0063,0.0036 0.01226,0.0076 0.01822,0.01147 0.0086,0.0055 0.01697,0.01118 0.02492,0.01714 0.155457,0.11306 0.20546,0.286679 0.20546,0.473408 0.01067,0.158806 -0.0071,0.339292 -0.04518,0.522503 -7.38e-4,0.0035 -0.0017,0.007 -0.0025,0.01061 -0.336794,1.93637 -2.359208,3.610467 -2.359208,3.610467 z M 18.037876,32.569197 C 17.825038,32.364589 17.624743,32.146984 17.438297,31.9178 17.31417,31.763478 17.195889,31.604389 17.083511,31.440986 c -0.111925,-0.1638 -0.216187,-0.332991 -0.316079,-0.504908 -0.199216,-0.3444 -0.371927,-0.705543 -0.519664,-1.078321 -0.296384,-0.745443 -0.49123,-1.538108 -0.594811,-2.348879 -0.02736,-0.202451 -0.04745,-0.406492 -0.06323,-0.611213 -0.01578,-0.2037 -0.02509,-0.414041 -0.03014,-0.609284 l -0.0042,-0.315454 c 7.94e-4,-0.09813 0.0012,-0.196208 0.0061,-0.294908 0.0075,-0.197116 0.02338,-0.395311 0.04722,-0.593789 0.08888,-0.794935 0.292922,-1.592141 0.571768,-2.368289 0.140756,-0.387819 0.299108,-0.771665 0.478686,-1.146941 0.1764,-0.376865 0.375162,-0.744251 0.586751,-1.10477 0.425392,-0.719846 0.921503,-1.401154 1.480387,-2.025025 0.280605,-0.310516 0.576308,-0.607864 0.890513,-0.88251 0.313354,-0.275668 0.641465,-0.533741 0.987114,-0.763436 0.689538,-0.460127 1.444743,-0.818545 2.236159,-1.011632 0.197741,-0.04716 0.397298,-0.08593 0.598103,-0.112265 0.05006,-0.0078 0.10046,-0.01141 0.150689,-0.01737 0.05063,-0.0059 0.1008,-0.01118 0.147795,-0.01374 l 0.145013,-0.01033 0.1659,-0.0052 0.04143,-0.0012 c 0.0066,-1.13e-4 0.0077,-1.7e-4 0.0076,-2.27e-4 2.84e-4,0 6.81e-4,5.7e-5 0.0024,1.14e-4 l 0.01884,3.4e-4 0.07526,0.0013 c 0.05017,0.0012 0.100516,9.08e-4 0.150576,0.003 0.09989,0.0081 0.200578,0.0092 0.299846,0.02287 l 0.14927,0.01731 0.148078,0.02446 c 0.09921,0.01396 0.195981,0.03922 0.293887,0.05925 0.775467,0.189283 1.497243,0.584197 2.047727,1.14484 l 0.05239,0.05159 0.04961,0.05426 0.09921,0.108348 0.09331,0.1134 0.0466,0.05659 0.04359,0.05903 0.08723,0.117713 0.08099,0.122141 0.04058,0.06084 0.03735,0.063 0.07463,0.125716 c 0.189341,0.341279 0.33373,0.706054 0.434984,1.083487 0.04739,0.189794 0.09092,0.380724 0.115784,0.575967 0.0063,0.04875 0.01532,0.09688 0.01975,0.145979 l 0.01436,0.147056 0.0075,0.07339 0.0037,0.06998 0.0076,0.139168 0.002,0.03479 5.67e-4,0.04064 6.25e-4,0.08298 0.0019,0.165956 -0.0036,0.136557 -0.0068,0.151087 c -0.01152,0.201373 -0.03025,0.402689 -0.05835,0.60321 -0.110165,0.803109 -0.3612,1.59146 -0.701967,2.346495 -0.34389,0.754581 -0.779554,1.47596 -1.276006,2.159368 -0.496792,0.683692 -1.055221,1.329243 -1.654232,1.93864 -0.599522,0.609341 -1.239852,1.182868 -1.909354,1.722511 -0.669106,0.540324 -1.369541,1.044211 -2.092452,1.513646 -0.918267,0.594413 -1.873086,1.136213 -2.856227,1.610813 z M 25,41.567811 c -4.800486,0 -9.092886,-2.173387 -11.948546,-5.589235 0.422724,-0.0798 0.836708,-0.177649 1.243257,-0.290027 0.898119,-0.24973 1.763432,-0.564219 2.606384,-0.919687 0.271581,-0.115159 0.540551,-0.234973 0.807591,-0.358192 0.02503,0.01754 0.04989,0.0353 0.07509,0.05261 0.201146,0.138373 0.407854,0.268346 0.619954,0.387875 0.84664,0.482887 1.769108,0.812303 2.705992,1.000963 0.234405,0.04677 0.469662,0.08712 0.7056,0.116578 0.235767,0.03116 0.472046,0.05352 0.708154,0.06782 0.236051,0.01612 0.471932,0.02089 0.707302,0.02231 l 0.176344,-0.0015 0.09166,-0.0013 0.08298,-0.0024 c 0.107554,-0.0025 0.227708,-0.0079 0.345479,-0.01288 0.924227,-0.0441 1.843402,-0.165048 2.744302,-0.370111 0.901014,-0.202564 1.783581,-0.485156 2.631584,-0.846924 1.543159,-0.656278 2.977062,-1.565635 4.209989,-2.702927 0.375673,0.06482 0.753843,0.0937 1.128268,0.09399 l 0.183324,-0.0041 c 0.02997,-0.0012 0.05381,-2.84e-4 0.08877,-0.0032 l 0.09876,-0.0069 c 0.1344,-0.0072 0.256711,-0.02486 0.382427,-0.04018 0.249673,-0.03825 0.496736,-0.09422 0.738236,-0.167262 0.24184,-0.07236 0.475791,-0.167035 0.702591,-0.27334 0.226857,-0.106646 0.445257,-0.22873 0.652987,-0.364265 0.20807,-0.135081 0.407741,-0.280946 0.597195,-0.436971 0.188943,-0.156591 0.368975,-0.321754 0.540778,-0.493556 0.342016,-0.344968 0.651624,-0.715476 0.931208,-1.102954 0.335092,-0.462738 0.630738,-0.946987 0.896984,-1.44429 C 39.527403,35.590076 32.962235,41.567811 25,41.567811 Z"
+       id="path9" /><text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:16px;font-family:Inter;-inkscape-font-specification:'Inter Medium';text-align:start;letter-spacing:-0.5px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#206b00;stroke:#206b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round"
+       x="47.153763"
+       y="39.390961"
+       id="text14"><tspan
+         sodipodi:role="line"
+         id="tspan14"
+         x="47.153763"
+         y="39.390961"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16px;font-family:Inter;-inkscape-font-specification:'Inter Bold';letter-spacing:-0.5px;fill:#206b00;stroke:#206b00;stroke-linecap:butt;stroke-linejoin:round">elementary OS</tspan></text><text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:13.3333px;font-family:Inter;-inkscape-font-specification:'Inter Medium';text-align:start;letter-spacing:0.5px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#206b00;stroke:#206b00;stroke-width:1;stroke-linejoin:round;stroke-dasharray:none"
+       x="47.153763"
+       y="21.830704"
+       id="text13"><tspan
+         sodipodi:role="line"
+         id="tspan13"
+         x="47.153763"
+         y="21.830704"
+         style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:13.3333px;font-family:Inter;-inkscape-font-specification:'Inter Medium';letter-spacing:0.5px;fill:#206b00;stroke:#206b00;stroke-width:1;stroke-dasharray:none">Made for</tspan></text><text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.3333px;font-family:Inter;-inkscape-font-specification:Inter;text-align:start;letter-spacing:0.5px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:0.4;fill:#206b00;stroke:#206b00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none"
+       x="81.306419"
+       y="-10.698213"
+       id="text15"><tspan
+         sodipodi:role="line"
+         id="tspan15"
+         x="81.306419"
+         y="-10.698213" /></text></g><path
+     style="fill:#ffffff;stroke-width:0.0566667;fill-opacity:1"
+     d="M 25,8.0000001 C 15.611127,8.0000001 8,15.611127 8,25 8,34.388873 15.611127,42 25,42 34.388873,42 42,34.388873 42,25 42,15.611127 34.388873,8.0000001 25,8.0000001 Z M 12.68112,33.2722 c -0.202527,0.02454 -0.40409,0.04057 -0.603273,0.05004 -0.06794,0.0033 -0.135547,0.0052 -0.202867,0.0063 C 10.344187,30.9211 9.456957,28.06425 9.456957,25 9.456957,16.415793 16.415793,9.4569001 25,9.4569001 c 8.342013,0 15.148247,6.5718599 15.525817,14.8205999 -0.143877,0.40086 -0.30209,0.796733 -0.47532,1.18473 -0.361704,0.80716 -0.785514,1.58525 -1.295797,2.28922 -0.25415,0.352467 -0.532043,0.683797 -0.832377,0.98685 -0.15079,0.150733 -0.30736,0.294157 -0.469653,0.428797 -0.16269,0.134016 -0.332123,0.257436 -0.5066,0.370826 -0.17425,0.1139 -0.355243,0.214767 -0.54128,0.30209 -0.186093,0.08698 -0.37621,0.16439 -0.57171,0.222644 -0.19516,0.05888 -0.394003,0.103926 -0.59534,0.135036 -0.100753,0.0119 -0.20434,0.02692 -0.29801,0.03156 l -0.07191,0.0056 c -0.02187,0.0025 -0.05514,0.0019 -0.08211,0.003 l -0.158723,0.0038 c -0.08738,-5.7e-5 -0.174477,-0.0024 -0.261347,-0.006 0.45356,-0.50473 0.867963,-1.047823 1.227797,-1.63506 0.243213,-0.400463 0.459623,-0.822856 0.627016,-1.27874 0.0833,-0.228083 0.15385,-0.465006 0.202074,-0.71502 0.04766,-0.2499 0.07508,-0.5134 0.05287,-0.795883 -0.01133,-0.14093 -0.03598,-0.287017 -0.08319,-0.4352 -0.04607,-0.14756 -0.115883,-0.297557 -0.214257,-0.43537 -0.09701,-0.138078 -0.22457,-0.260534 -0.36448,-0.354318 -0.140476,-0.09299 -0.292003,-0.1598 -0.440073,-0.200826 -0.148353,-0.04193 -0.29393,-0.06296 -0.43384,-0.07095 -0.03536,-0.0026 -0.06964,-0.003 -0.104153,-0.0036 l -0.02584,-3.97e-4 h -0.03224 l -0.04142,8.5e-4 -0.04137,8.5e-4 -0.05072,0.0024 c -0.03445,0.0021 -0.07197,0.0032 -0.103757,0.0067 -0.262197,0.02119 -0.53363,0.07848 -0.79339,0.18938 -0.259363,0.10999 -0.504107,0.274493 -0.701533,0.478267 -0.199297,0.202753 -0.351107,0.43894 -0.463647,0.680906 -0.01303,0.02828 -0.02544,0.05667 -0.03751,0.08517 -0.03485,-0.03916 -0.07066,-0.07786 -0.10863,-0.115486 -0.202867,-0.20094 -0.459,-0.37621 -0.7514,-0.476907 -0.145237,-0.05089 -0.297387,-0.08279 -0.448347,-0.09639 -0.07582,-0.0065 -0.14994,-0.0098 -0.225817,-0.0073 l -0.03723,0.0021 -0.04074,0.003 c -0.02306,0.0027 -0.04613,0.0053 -0.06925,0.0089 -0.04624,0.0075 -0.09254,0.01694 -0.138266,0.02986 -0.18394,0.04992 -0.35462,0.14824 -0.487787,0.26758 -0.13464,0.11934 -0.234317,0.256473 -0.311043,0.394003 -0.151924,0.2771 -0.219187,0.55777 -0.251884,0.829487 -0.06007,0.544453 0.02153,1.06607 0.18292,1.555443 0.163257,0.488864 0.416104,0.94486 0.74103,1.34266 0.32453,0.39814 0.721934,0.73576 1.160817,0.994897 0.15793,0.09367 0.321073,0.1768 0.48756,0.250637 -1.02833,0.81991 -2.181553,1.486423 -3.402607,1.971263 -0.788063,0.309853 -1.603043,0.549383 -2.433323,0.70805 -0.830393,0.15674 -1.675067,0.238963 -2.518607,0.245197 -0.427606,0.0024 -0.836513,-0.01179 -1.24695,-0.05627 -0.204623,-0.02122 -0.407886,-0.04927 -0.609223,-0.0848 -0.201733,-0.03383 -0.400917,-0.07712 -0.598343,-0.12529 -0.72913,-0.179293 -1.424317,-0.45866 -2.058757,-0.830733 0.795883,-0.430724 1.56859,-0.901 2.32101,-1.401764 1.505237,-1.009233 2.93063,-2.147213 4.20495,-3.458196 0.636593,-0.655237 1.23505,-1.35371 1.773893,-2.10392 0.269847,-0.374624 0.52343,-0.76313 0.75888,-1.1645 0.234204,-0.402107 0.44829,-0.81838 0.638464,-1.247857 0.379213,-0.858727 0.655406,-1.77803 0.77214,-2.730257 0.02907,-0.23783 0.04913,-0.477246 0.05706,-0.71757 0.0013,-0.06012 0.0036,-0.12019 0.0041,-0.180313 l -2.27e-4,-0.194933 -0.0058,-0.16558 -0.0032,-0.08279 -0.0019,-0.04216 -0.0038,-0.04794 -0.0157,-0.191534 -0.0085,-0.09531 -0.01196,-0.09118 -0.02471,-0.18224 C 29.8244,18.406043 29.8111,18.345747 29.80039,18.285283 29.758,18.043373 29.6938,17.80475 29.622797,17.56879 29.474274,17.098117 29.26098,16.646823 28.997764,16.228737 l -0.103323,-0.154134 -0.05196,-0.07667 -0.05548,-0.07435 -0.11118,-0.14807 -0.118206,-0.142574 -0.05933,-0.07095 -0.06256,-0.06817 -0.12529,-0.135944 -0.13141,-0.12988 -0.06602,-0.06454 -0.06879,-0.06148 c -0.180087,-0.167904 -0.377854,-0.31467 -0.57681,-0.4573 -0.10268,-0.06692 -0.20247,-0.13804 -0.309004,-0.198277 -0.05281,-0.03088 -0.104776,-0.06307 -0.15827,-0.09259 l -0.161896,-0.08562 C 26.404313,14.04452 25.9435,13.878487 25.47209,13.766343 c -0.11866,-0.02403 -0.236243,-0.05429 -0.356037,-0.07163 l -0.179066,-0.02947 -0.18003,-0.02148 c -0.119794,-0.01728 -0.240494,-0.02131 -0.360854,-0.03185 -0.06024,-0.0033 -0.12053,-0.0041 -0.180823,-0.0061 l -0.09044,-0.0026 -0.02261,-6.24e-4 -0.03145,-5.6e-5 -0.04142,3.4e-4 -0.165637,0.0012 -0.186037,0.0081 c -0.06341,0.0023 -0.123306,0.0072 -0.182636,0.01247 -0.05967,0.0056 -0.11968,0.009 -0.179067,0.01655 -0.238453,0.02544 -0.47413,0.06647 -0.708333,0.11322 -0.935567,0.19771 -1.81662,0.574147 -2.62446,1.05077 -0.810844,0.47566 -1.54581,1.061027 -2.21714,1.70697 -0.669347,0.64872 -1.269957,1.36561 -1.797467,2.13537 -0.52683,0.770157 -0.980673,1.594487 -1.338297,2.467833 -0.359323,0.8721 -0.622993,1.794464 -0.75021,2.75553 -0.03162,0.240097 -0.05321,0.4828 -0.06511,0.727317 -0.0071,0.12206 -0.0093,0.24497 -0.01116,0.367937 l -5.1e-4,0.05349 1.7e-4,0.04142 3.97e-4,0.08285 7.36e-4,0.08279 3.97e-4,0.04148 0.0012,0.04562 c 0.006,0.24667 0.0166,0.478153 0.03462,0.715246 0.01802,0.236074 0.04125,0.472204 0.07287,0.70788 0.06233,0.47124 0.154587,0.940554 0.27387,1.404654 0.122514,0.463533 0.274607,0.921116 0.45968,1.367536 0.185754,0.446024 0.405337,0.87992 0.657334,1.296024 0.25347,0.415196 0.541506,0.810673 0.859463,1.181273 0.08358,0.09645 0.16915,0.191193 0.256643,0.28424 -0.03088,0.01213 -0.06165,0.02465 -0.09259,0.03661 -0.796337,0.307473 -1.60854,0.566043 -2.424937,0.75157 -0.407886,0.09225 -0.81685,0.16592 -1.222073,0.213293 z m 20.390367,-3.247453 c -0.10149,0 -0.479344,-0.13583 -0.9095,-0.42126 C 31.855023,29.4098 31.580473,29.1701 31.35171,28.891753 30.936003,28.405893 30.61,27.75638 30.61,26.926667 c 0,-0.54774 0.146257,-0.910974 0.462797,-0.910974 0.06947,0 0.142233,0.0123 0.216806,0.03349 0.02624,0.0065 0.05213,0.01383 0.07758,0.02278 0.03899,0.01343 0.07718,0.03009 0.11475,0.0493 0.6154,0.28373 1.27721,1.04142 1.27721,1.04142 0,0 0.536633,-1.87935 1.987527,-1.87935 0.200543,0 0.34833,0.03423 0.457186,0.0914 0.0076,0.0039 0.01536,0.0077 0.02244,0.01179 0.0063,0.0036 0.01224,0.0076 0.01819,0.01145 0.0086,0.0055 0.01694,0.01116 0.02488,0.01711 0.15521,0.11288 0.205133,0.286224 0.205133,0.472657 0.01065,0.158553 -0.0071,0.338753 -0.04511,0.521673 -7.37e-4,0.0035 -0.0017,0.007 -0.0025,0.0106 -0.33626,1.933297 -2.355463,3.604737 -2.355463,3.604737 z M 18.048927,31.55877 C 17.836427,31.354487 17.63645,31.137227 17.4503,30.908407 17.32637,30.75433 17.208277,30.595493 17.096077,30.43235 16.98433,30.26881 16.880233,30.099887 16.7805,29.928243 16.5816,29.58439 16.409163,29.22382 16.26166,28.851633 c -0.295913,-0.74426 -0.49045,-1.535666 -0.593867,-2.34515 -0.02731,-0.20213 -0.04737,-0.405846 -0.06313,-0.610243 -0.01575,-0.203377 -0.02505,-0.413383 -0.03009,-0.608317 l -0.0042,-0.314953 c 7.93e-4,-0.09798 0.0012,-0.195897 0.0061,-0.29444 0.0075,-0.196803 0.02335,-0.394683 0.04715,-0.592847 0.08874,-0.793673 0.292456,-1.589613 0.57086,-2.36453 0.140533,-0.387203 0.298633,-0.77044 0.477926,-1.14512 0.17612,-0.376266 0.374567,-0.74307 0.58582,-1.103016 0.424717,-0.718704 0.92004,-1.39893 1.478037,-2.02181 0.28016,-0.310024 0.575393,-0.6069 0.8891,-0.88111 0.312857,-0.27523 0.640447,-0.532894 0.985547,-0.762224 0.688443,-0.459396 1.44245,-0.817246 2.23261,-1.010026 0.197426,-0.04709 0.396666,-0.08579 0.597153,-0.112087 0.04998,-0.0077 0.1003,-0.01139 0.15045,-0.01734 0.05055,-0.0059 0.10064,-0.01116 0.14756,-0.01371 l 0.144783,-0.01031 0.165637,-0.0052 0.04137,-0.0012 c 0.0066,-1.13e-4 0.0076,-1.7e-4 0.0076,-2.27e-4 2.84e-4,0 6.8e-4,5.7e-5 0.0024,1.14e-4 l 0.01881,3.4e-4 0.07514,0.0013 c 0.05009,0.0012 0.100356,9.07e-4 0.150336,0.003 0.09973,0.0081 0.20026,0.0092 0.29937,0.02284 l 0.149034,0.01728 0.147843,0.02442 c 0.09905,0.01394 0.19567,0.03916 0.29342,0.05916 0.774237,0.188983 1.494867,0.58327 2.044477,1.143023 l 0.0523,0.05151 0.04953,0.05417 0.09905,0.108177 0.09316,0.11322 0.04652,0.0565 0.04352,0.05893 0.0871,0.117527 0.08086,0.121946 0.04052,0.06075 0.03729,0.0629 0.07452,0.125517 c 0.18904,0.340736 0.3332,0.704933 0.434294,1.081766 0.04732,0.189494 0.09078,0.38012 0.1156,0.575054 0.0063,0.04868 0.0153,0.09673 0.01972,0.145746 l 0.01434,0.146824 0.0075,0.07327 0.0037,0.06987 0.0076,0.138946 0.002,0.03474 5.66e-4,0.04057 6.24e-4,0.08285 0.0019,0.165693 -0.0036,0.13634 -0.0068,0.150847 c -0.0115,0.201053 -0.0302,0.40205 -0.05825,0.602253 -0.10999,0.801834 -0.360626,1.588934 -0.700853,2.34277 -0.343343,0.753384 -0.778317,1.473617 -1.27398,2.15594 -0.496003,0.682607 -1.053547,1.327134 -1.651607,1.935564 -0.59857,0.608373 -1.237883,1.18099 -1.906323,1.719776 -0.668043,0.539467 -1.367367,1.042554 -2.08913,1.511244 -0.91681,0.59347 -1.870113,1.13441 -2.851693,1.608256 z M 25,40.5431 c -4.792867,0 -9.078453,-2.169937 -11.92958,-5.580363 0.422053,-0.07967 0.83538,-0.177367 1.241283,-0.289567 0.896694,-0.249333 1.760634,-0.563323 2.602247,-0.918227 0.27115,-0.114976 0.539693,-0.2346 0.80631,-0.357623 0.02499,0.01751 0.04981,0.03525 0.07497,0.05253 0.200827,0.138153 0.407207,0.26792 0.61897,0.38726 0.845297,0.48212 1.7663,0.811013 2.701697,0.999373 0.234033,0.04669 0.468916,0.08698 0.70448,0.116394 0.235393,0.03111 0.471296,0.05344 0.70703,0.06772 0.235676,0.01609 0.471183,0.02085 0.70618,0.02227 l 0.176063,-0.0015 0.09152,-0.0013 0.08285,-0.0024 c 0.107384,-0.0025 0.227347,-0.0078 0.34493,-0.01286 0.92276,-0.04403 1.840477,-0.164787 2.739947,-0.369524 0.899583,-0.202243 1.78075,-0.484386 2.627407,-0.84558 1.54071,-0.655236 2.972336,-1.56315 4.203306,-2.698636 0.375077,0.06471 0.752647,0.09356 1.126477,0.09384 l 0.183033,-0.0041 c 0.02992,-0.0012 0.05372,-2.83e-4 0.08863,-0.0032 l 0.0986,-0.0069 c 0.134187,-0.0072 0.256303,-0.02482 0.38182,-0.04012 0.249277,-0.03819 0.495947,-0.09407 0.737063,-0.166997 0.241457,-0.07225 0.475037,-0.16677 0.701477,-0.272906 0.226497,-0.106477 0.44455,-0.228367 0.65195,-0.363687 0.20774,-0.134867 0.407093,-0.2805 0.596247,-0.436277 0.188643,-0.156343 0.36839,-0.321243 0.53992,-0.492773 0.341473,-0.34442 0.65059,-0.71434 0.92973,-1.101203 0.33456,-0.462004 0.629736,-0.945484 0.89556,-1.441997 C 39.504343,34.574853 32.949597,40.5431 25,40.5431 Z"
+     id="path1" /><path
+     style="fill:#da4d45;stroke-width:0.0566667"
+     d="m 33.071487,30.024747 c 0,0 2.40312,-1.98883 2.40312,-4.137007 0,-0.321073 -0.145804,-0.604407 -0.72794,-0.604407 -1.450894,0 -1.98747,1.87935 -1.98747,1.87935 0,0 -1.00181,-1.14699 -1.6864,-1.14699 -0.31654,0 -0.462797,0.363234 -0.462797,0.910974 0,2.153333 2.193453,3.09808 2.461487,3.09808 z"
+     id="path2" /><text
+     xml:space="preserve"
+     style="font-size:6px;font-family:'Roboto Mono';-inkscape-font-specification:'Roboto Mono';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:0.15;fill:#fafafa;stroke:#206b00;stroke-width:2;stroke-linejoin:round"
+     x="108"
+     y="-32"
+     id="text3"><tspan
+       sodipodi:role="line"
+       id="tspan3"
+       x="108"
+       y="-32" /></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6px;font-family:Inter;-inkscape-font-specification:Inter;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#fafafa;stroke:none;stroke-width:2;stroke-linejoin:round"
+     x="82.5"
+     y="-3.5"
+     id="text4"><tspan
+       sodipodi:role="line"
+       id="tspan4"
+       x="82.5"
+       y="-3.5" /></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;font-family:Inter;-inkscape-font-specification:Inter;text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#fafafa;stroke:none;stroke-width:2;stroke-linejoin:round"
+     x="83"
+     y="-8"
+     id="text5"><tspan
+       sodipodi:role="line"
+       id="tspan5"
+       x="83"
+       y="-8" /></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;font-family:'Inter Display';-inkscape-font-specification:'Inter Display';text-align:start;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#fafafa;stroke:none;stroke-width:2;stroke-linejoin:round"
+     x="71.881882"
+     y="-3.691509"
+     id="text6"><tspan
+       sodipodi:role="line"
+       id="tspan6"
+       x="71.881882"
+       y="-3.691509" /></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;font-family:'Inter Display';-inkscape-font-specification:'Inter Display';text-align:start;letter-spacing:0.75px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#fafafa;stroke:none;stroke-width:2;stroke-linejoin:round"
+     x="102.16647"
+     y="-16.730618"
+     id="text7"><tspan
+       sodipodi:role="line"
+       id="tspan7"
+       x="102.16647"
+       y="-16.730618" /></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;font-family:'Inter Display';-inkscape-font-specification:'Inter Display';text-align:start;letter-spacing:0.5px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#fafafa;stroke:none;stroke-width:2;stroke-linejoin:round"
+     x="81.733177"
+     y="-34.421188"
+     id="text8"><tspan
+       sodipodi:role="line"
+       id="tspan8"
+       x="81.733177"
+       y="-34.421188" /></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.6667px;font-family:Inter;-inkscape-font-specification:Inter;text-align:start;letter-spacing:0.5px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:0.2;fill:#206b00;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round"
+     x="97.185432"
+     y="-25.196224"
+     id="text12"><tspan
+       sodipodi:role="line"
+       id="tspan12"
+       x="97.185432"
+       y="-25.196224" /></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:16px;font-family:Inter;-inkscape-font-specification:'Inter Medium';text-align:start;letter-spacing:-0.5px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#ffffff;stroke-width:2;stroke-linejoin:round;fill-opacity:1"
+     x="47.153763"
+     y="38.390961"
+     id="text9"><tspan
+       sodipodi:role="line"
+       id="tspan1"
+       x="47.153763"
+       y="38.390961"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:16px;font-family:Inter;-inkscape-font-specification:'Inter Bold';letter-spacing:-0.5px;fill:#ffffff;fill-opacity:1">elementary OS</tspan></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:13.3333px;font-family:Inter;-inkscape-font-specification:'Inter Medium';text-align:start;letter-spacing:0.5px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#ffffff;stroke-width:2;stroke-linejoin:round;fill-opacity:1"
+     x="47.153763"
+     y="20.830704"
+     id="text10"><tspan
+       sodipodi:role="line"
+       id="tspan10"
+       x="47.153763"
+       y="20.830704"
+       style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:13.3333px;font-family:Inter;-inkscape-font-specification:'Inter Medium';letter-spacing:0.5px;fill:#ffffff;fill-opacity:1">Made for</tspan></text><text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;font-family:Inter;-inkscape-font-specification:Inter;text-align:start;letter-spacing:-1px;writing-mode:lr-tb;direction:ltr;text-anchor:start;opacity:1;fill:#fafafa;stroke-width:2;stroke-linejoin:round"
+     x="102.83233"
+     y="-16.113329"
+     id="text11"><tspan
+       sodipodi:role="line"
+       id="tspan11"
+       x="102.83233"
+       y="-16.113329" /></text></svg>


### PR DESCRIPTION
The previous implementation of this idea used an encoded SVG that made it really difficult to tell what actually was going on in the markup. This redesigns the badge, then hosts it here so we don't have to embed anything and it's easily copy-paste-able between repos.

```html
  <a href="https://elementary.io">
    <img src="https://ellie-commons.github.io/community-badge.svg" alt="Made for elementary OS">
  </a>
```

  <a href="https://elementary.io">
    <img src="https://github.com/ellie-commons/ellie-commons.github.io/blob/1abe3351f64d080ea9f5e451862e0020056d6fc3/community-badge.svg" alt="Made for elementary OS">
  </a>